### PR TITLE
chore(package.json): Bump ara-context to 0.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/arablocks/ara-util#readme",
   "dependencies": {
-    "ara-context": "github:arablocks/ara-context#semver:0.3.x",
+    "ara-context": "github:arablocks/ara-context#semver:0.4.x",
     "ara-crypto": "github:arablocks/ara-crypto#semver:0.7.x",
     "ara-filesystem": "github:arablocks/ara-filesystem#semver:0.2.x",
     "ara-identity": "github:arablocks/ara-identity#semver:0.28.x",


### PR DESCRIPTION
Fixes # AraBlocks/ara-context#9

## Proposed Changes

  - require version of ara-context that handles not having `web3.provider` set in .ararc
  -
  -