### PR TITLE
fix(web3/contract.js): sign contract deployments

### DIFF
--- a/web3/contract.js
+++ b/web3/contract.js
@@ -1,3 +1,4 @@
+const tx = require('./tx')
 const { web3 } = require('ara-context')()
 
 /**
@@ -36,11 +37,17 @@ async function deploy(opts) {
         arguments: args
       })
     const gasLimit = await contract.estimateGas()
+
+    const deployTx = await tx.create({
+      account,
+      gasLimit,
+      data: contract.encodeABI()
+    })
+
+    const { contractAddress } = await tx.sendSignedTransaction(deployTx)
+
     return {
-      contract: await contract.send({
-        from: address,
-        gas: gasLimit
-      }),
+      contractAddress
       gasLimit
     }
   } catch (err) {


### PR DESCRIPTION
As Infura is an external provider, contract deployments need to be signed locally before being sent to the network. Previously, standard deployments were not sent using `sendSignedTransaction`, this PR resolves that so we can deploy using Infura.