### PR TITLE
fix(web3/tx): Remove passing obj into new Error

### DIFF
--- a/web3/tx.js
+++ b/web3/tx.js
@@ -170,7 +170,7 @@ async function _send(tx, signed) {
       result = await web3.eth.sendTransaction(tx)
     }
   } catch (err) {
-    throw new Error(err)
+    throw new Error(err.message)
   }
   ctx.close()
   return result


### PR DESCRIPTION
Fixes issue with calls to `_send` and an error occurring (for instance: insufficient funds) then getting an error with `[object Object]`